### PR TITLE
doc: support most GMxhr options in GM_download

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -298,17 +298,13 @@ declare interface VMScriptResponseObject<T> {
   context?: unknown;
 }
 
-declare interface VMScriptGMXHRDetails<T = string | Blob | ArrayBuffer | Document | object> {
+interface GMRequestBase<T = string | Blob | ArrayBuffer | Document | object> {
   /** URL relative to current page is also allowed. */
   url: string;
-  /** HTTP method, default as `GET`. */
-  method?: string;
   /** User for authentication. */
   user?: string;
   /** Password for authentication. */
   password?: string;
-  /** A MIME type to specify with the request. */
-  overrideMimeType?: string;
   /**
    * Some special headers are also allowed:
    *
@@ -319,22 +315,8 @@ declare interface VMScriptGMXHRDetails<T = string | Blob | ArrayBuffer | Documen
    * - `User-Agent`
    */
   headers?: Record<string, string>;
-  /**
-   * One of the following:
-   *
-   * - `text` (default value)
-   * - `json`
-   * - `blob`
-   * - `arraybuffer`
-   * - `document`
-   */
-  responseType?: VMScriptResponseType;
   /** Time to wait for the request, none by default. */
   timeout?: number;
-  /** Data to send with the request, usually for `POST` and `PUT` requests. */
-  data?: string | FormData | Blob;
-  /** Send the `data` string as a `blob`. This is for compatibility with Tampermonkey/Greasemonkey, where only `string` type is allowed in `data`. */
-  binary?: boolean;
   /** Can be an object and will be assigned to context of the response object. */
   context?: unknown;
   /** When set to `true`, no cookie will be sent with the request and the response cookies will be ignored. The default value is `false`. */
@@ -349,10 +331,31 @@ declare interface VMScriptGMXHRDetails<T = string | Blob | ArrayBuffer | Documen
   ontimeout?: (resp: VMScriptResponseObject<T>) => void;
 }
 
-/** Makes a request like XMLHttpRequest, with some special capabilities, not restricted by same-origin policy. */
-declare function GM_xmlhttpRequest(details: VMScriptGMXHRDetails): VMScriptXHRControl;
+declare interface VMScriptGMXHRDetails<T> extends GMRequestBase<T> {
+  /** HTTP method, default as `GET`. */
+  method?: string;
+  /** A MIME type to specify with the request. */
+  overrideMimeType?: string;
+  /**
+   * One of the following:
+   *
+   * - `text` (default value)
+   * - `json`
+   * - `blob`
+   * - `arraybuffer`
+   * - `document`
+   */
+  responseType?: VMScriptResponseType;
+  /** Data to send with the request, usually for `POST` and `PUT` requests. */
+  data?: string | ArrayBuffer | Blob | DataView | FormData | ReadableStream | TypedArray | URLSearchParams;
+  /** Send the `data` string as a `blob`. This is for compatibility with Tampermonkey/Greasemonkey, where only `string` type is allowed in `data`. */
+  binary?: boolean;
+}
 
-declare interface VMScriptGMDownloadOptions extends Omit<VMScriptGMXHRDetails<Blob>, 'binary' | 'data' | 'method' | 'overrideMimeType' | 'responseType'> {
+/** Makes a request like XMLHttpRequest, with some special capabilities, not restricted by same-origin policy. */
+declare function GM_xmlhttpRequest<T>(details: VMScriptGMXHRDetails<T>): VMScriptXHRControl;
+
+declare interface VMScriptGMDownloadOptions extends GMRequestBase<Blob> {
   /** The filename to save as. */
   name: string;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -281,7 +281,7 @@ declare type VMScriptResponseType = 'text' | 'json' | 'blob' | 'arraybuffer' | '
  * https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest#properties
  * https://developer.mozilla.org/en-US/docs/Web/API/ProgressEvent#properties
  */
-declare interface VMScriptResponseObject<T = string | Blob | ArrayBuffer | Document | object> {
+declare interface VMScriptResponseObject<T> {
   status: number;
   statusText: string;
   readyState: number;
@@ -298,7 +298,7 @@ declare interface VMScriptResponseObject<T = string | Blob | ArrayBuffer | Docum
   context?: unknown;
 }
 
-declare interface VMScriptGMXHRDetails<T> {
+declare interface VMScriptGMXHRDetails<T = string | Blob | ArrayBuffer | Document | object> {
   /** URL relative to current page is also allowed. */
   url: string;
   /** HTTP method, default as `GET`. */
@@ -350,20 +350,11 @@ declare interface VMScriptGMXHRDetails<T> {
 }
 
 /** Makes a request like XMLHttpRequest, with some special capabilities, not restricted by same-origin policy. */
-declare function GM_xmlhttpRequest<T>(details: VMScriptGMXHRDetails<T>): VMScriptXHRControl;
+declare function GM_xmlhttpRequest(details: VMScriptGMXHRDetails): VMScriptXHRControl;
 
-declare interface VMScriptGMDownloadOptions {
-  /** The URL to download. */
-  url: string;
+declare interface VMScriptGMDownloadOptions extends Omit<VMScriptGMXHRDetails<Blob>, 'binary' | 'data' | 'method' | 'overrideMimeType' | 'responseType'> {
   /** The filename to save as. */
-  name?: string;
-  /** The function to call when download starts successfully. */
-  onload?: () => void;
-  headers?: Record<string, string>;
-  timeout?: number;
-  onerror?: (resp: VMScriptResponseObject<Blob>) => void;
-  onprogress?: (resp: VMScriptResponseObject<Blob>) => void;
-  ontimeout?: (resp: VMScriptResponseObject<Blob>) => void;
+  name: string;
 }
 
 /** Downloads a URL to a local file. */
@@ -372,7 +363,7 @@ declare function GM_download(
   /** The URL to download. */
   url: string,
   /** The filename to save as. */
-  name?: string
+  name: string
 ): void;
 
 /** Aliases for GM_ methods that are not included in Greasemonkey4 API */

--- a/index.d.ts
+++ b/index.d.ts
@@ -298,7 +298,7 @@ declare interface VMScriptResponseObject<T> {
   context?: unknown;
 }
 
-interface GMRequestBase<T = string | Blob | ArrayBuffer | Document | object> {
+interface GMRequestBase<T> {
   /** URL relative to current page is also allowed. */
   url: string;
   /** User for authentication. */
@@ -353,7 +353,9 @@ declare interface VMScriptGMXHRDetails<T> extends GMRequestBase<T> {
 }
 
 /** Makes a request like XMLHttpRequest, with some special capabilities, not restricted by same-origin policy. */
-declare function GM_xmlhttpRequest<T>(details: VMScriptGMXHRDetails<T>): VMScriptXHRControl;
+declare function GM_xmlhttpRequest<T = string | Blob | ArrayBuffer | Document | object>(
+  details: VMScriptGMXHRDetails<T>
+): VMScriptXHRControl;
 
 declare interface VMScriptGMDownloadOptions extends GMRequestBase<Blob> {
   /** The filename to save as. */


### PR DESCRIPTION
In continuation of https://github.com/violentmonkey/violentmonkey/commit/7b91828d405d2eff645d890797fbff3f04936fd4

* Moved `<T>` to the root type, otherwise it didn't show hints inside VMScriptResponseObject.response.
* Removed `<T>` from `GM_xmlhttpRequest<T>` because it's unused
* `name` is mandatory
